### PR TITLE
Various improvements following real-world usage.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/gruntwork-io/gruntwork-cli"
   packages = ["entrypoint","errors","logging"]
-  revision = "17b672db77e9ecf979e3161ed497b54734fc75c8"
-  version = "v0.1.1"
+  revision = "94044eeeb0a48b5e8dd52190fa0d0daba53e157f"
+  version = "v0.1.2"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -40,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6d557096c548a55fecdfa45421ae26e5c332c54361713b2adf1d0ab0910fce64"
+  inputs-digest = "693562fc110c90f6529b2fc832c2a8548498219ae04ef05dafbc858eec4e1643"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/gruntwork-cli"
-  version = "0.1.1"
+  version = "0.1.2"
 
 [[constraint]]
   name = "github.com/urfave/cli"

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -48,7 +48,8 @@ func runHealthChecker(cliContext *cli.Context) error {
 	}
 
 	opts, err := parseOptions(cliContext)
-	if isSimpleError(err) {
+	if isDebugMode() {
+		opts.Logger.Infof("Note: To enable debug mode, set %s to \"true\"", ENV_VAR_NAME_DEBUG_MODE)
 		return err
 	}
 	if err != nil  {
@@ -57,7 +58,10 @@ func runHealthChecker(cliContext *cli.Context) error {
 
 	opts.Logger.Infof("The Health Check will attempt to connect to the following ports via TCP: %v", opts.Ports)
 	opts.Logger.Infof("Listening on Port %s...", opts.Listener)
-	server.StartHttpServer(opts)
+	err = server.StartHttpServer(opts)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
 
 	return nil
 }

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -47,6 +47,9 @@ func allCliOptionsEmpty(cliContext *cli.Context) bool {
 func parseOptions(cliContext *cli.Context) (*options.Options, error) {
 	logger := logging.GetLogger("health-checker")
 
+	// By default logrus logs to stderr. But since most output in this tool is informational, we default to stdout.
+	logger.Out = os.Stdout
+
 	logLevel := cliContext.String(logLevelFlag.Name)
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -6,10 +6,13 @@ import (
 	"github.com/gruntwork-io/gruntwork-cli/logging"
 	"github.com/urfave/cli"
 	"github.com/sirupsen/logrus"
+	"os"
+	"strings"
 )
 
 const DEFAULT_LISTENER_IP_ADDRESS = "0.0.0.0"
 const DEFAULT_LISTENER_PORT = 5500
+const ENV_VAR_NAME_DEBUG_MODE = "HEALTH_CHECKER_DEBUG"
 
 var portFlag = cli.IntSliceFlag{
 	Name: "port",
@@ -34,7 +37,8 @@ var defaultFlags = []cli.Flag{
 	logLevelFlag,
 }
 
-// Return true if all no options at all were passed to the CLI
+// Return true if no options at all were passed to the CLI. Note that we are specifically testing for flags, some of which
+// are required, not just args.
 func allCliOptionsEmpty(cliContext *cli.Context) bool {
 	return cliContext.NumFlags() == 0
 }
@@ -56,6 +60,9 @@ func parseOptions(cliContext *cli.Context) (*options.Options, error) {
 	}
 
 	listener := cliContext.String("listener")
+	if listener == "" {
+		return nil, MissingParam(listenerFlag.Name)
+	}
 
 	return &options.Options{
 		Ports:          ports,
@@ -64,13 +71,13 @@ func parseOptions(cliContext *cli.Context) (*options.Options, error) {
 	}, nil
 }
 
-// Some error types are simple enough that we'd rather just show the error message directly instead vomiting out a
-// whole stack trace in log output
-func isSimpleError(err error) bool {
-	_, isInvalidLogLevelErr := err.(InvalidLogLevel)
-	_, isMissingParam := err.(MissingParam)
-
-	return isInvalidLogLevelErr || isMissingParam
+// Some error types are simple enough that we'd rather just show the error message directly instead of vomiting out a
+// whole stack trace in log output. Therefore, allow a debug mode that always shows full stack traces. Otherwise, show
+// simple messages.
+func isDebugMode() bool {
+	envVar, _ := os.LookupEnv(ENV_VAR_NAME_DEBUG_MODE)
+	envVar = strings.ToLower(envVar)
+	return envVar == "true"
 }
 
 // Custom error types

--- a/server/server.go
+++ b/server/server.go
@@ -7,11 +7,16 @@ import (
 	"fmt"
 )
 
-func StartHttpServer(opts *options.Options) {
+func StartHttpServer(opts *options.Options) error {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		checkTcpPorts(w, r, opts)
 	})
-	http.ListenAndServe(opts.Listener, nil)
+	err := http.ListenAndServe(opts.Listener, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Check that we can open a TPC connection to all the ports in opts.Ports
@@ -24,7 +29,7 @@ func checkTcpPorts(w http.ResponseWriter, r *http.Request, opts *options.Options
 	for _, port := range opts.Ports {
 		err := attemptTcpConnection(port, opts)
 		if err != nil {
-			logger.Warnf("TCP connection to port %d FAILED!", port)
+			logger.Warnf("TCP connection to port %d FAILED: %s", port, err)
 			allPortsValid = false
 		} else {
 			logger.Infof("TCP connection to port %d successful", port)

--- a/server/server.go
+++ b/server/server.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"net/http"
-	"github.com/gruntwork-io/health-checker/options"
 	"net"
 	"fmt"
 	"sync"
 	"time"
-	"github.com/gruntwork-io/docs/errors"
+	"github.com/gruntwork-io/health-checker/options"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 type httpResponse struct {


### PR DESCRIPTION
- Health-checker now outputs to `stdout`, not `stderr`.
- Health checks are now handled in parallel, not serial.
- Additional errors that should have been caught are now explicitly logged where applicable.
- Introduced an env var, `HEALTH_CHECKER_DEBUG`. When set to `true`, health-checker will show the full stack trace on most error messages.