### PR TITLE
Added support for single flight checks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,6 +71,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0142c968b74c157abbb0220c05fa2bdde8a3a4509d6134b35ef75d5b58afb721"
+  name = "golang.org/x/sync"
+  packages = ["singleflight"]
+  pruneopts = ""
+  revision = "e225da77a7e68af35c70ccbf71af2b83e6acac3c"
+
+[[projects]]
+  branch = "master"
   digest = "1:6565b083c9a57815d2d05438244bb01a0a62efdc656dea8cfe2700b1e43aa6e9"
   name = "golang.org/x/sys"
   packages = [
@@ -90,6 +98,7 @@
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",
+    "golang.org/x/sync/singleflight",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,3 +27,7 @@
 [[constraint]]
   name = "github.com/urfave/cli"
   version = "1.20.0"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/sync"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # health-checker
 
 A simple HTTP server that will return `200 OK` if the configured checks are all successful.  If any of the checks fail,
-it will return `HTTP 504 Gateway Not Found`. 
+it will return `HTTP 504 Gateway Not Found`.
 
 ## Motivation
 
 We were setting up an AWS [Auto Scaling Group](http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroup.html)
-(ASG) fronted by a [Load Balancer](https://aws.amazon.com/documentation/elastic-load-balancing/) that used a 
+(ASG) fronted by a [Load Balancer](https://aws.amazon.com/documentation/elastic-load-balancing/) that used a
 [Health Check](http://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html#) to
 determine if the server is healthy. Each server in the ASG runs two services, which means that a server is "healthy" if
-the TCP Listeners of both services are successfully accepting connections. But the Load Balancer Health Check is limited to 
+the TCP Listeners of both services are successfully accepting connections. But the Load Balancer Health Check is limited to
 a single TCP port, or an HTTP(S) endpoint. As a result, our use case just isn't supported natively by AWS.
 
 We wrote health-checker so that we could run a daemon on the server that reports the true health of the server by
@@ -17,18 +17,18 @@ attempting to open a TCP connection to more than one port when it receives an in
 
 Using the `--script` -option, the `health-checker` can be extended to check many other targets. One concrete example is monitoring
 `ZooKeeper` node status during rolling deployment. Just polling the `ZooKeeper`'s TCP client port doesn't necessarily guarantee
-that the node has (re-)joined the cluster. Using the `health-check` with a custom script target, we can 
-[monitor ZooKeeper](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_monitoring) using the 
-[4 letter words](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_zkCommands), ensuring we report health back to the 
+that the node has (re-)joined the cluster. Using the `health-check` with a custom script target, we can
+[monitor ZooKeeper](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_monitoring) using the
+[4 letter words](https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_zkCommands), ensuring we report health back to the
 [Load Balancer](https://aws.amazon.com/documentation/elastic-load-balancing/) correctly.
 
 ## How It Works
 
 When health-checker is started, it will listen for inbound HTTP requests for any URL on the IP address and port specified
 by `--listener`. When it receives a request, it will attempt to open TCP connections to each of the ports specified by
-an instance of `--port` and/or execute the script target specified by `--script`. If all configured checks - all TCP 
-connections and zero exit status for the script - succeed, it will return `HTTP 200 OK`. If any of the checks fail, 
-it will return `HTTP 504 Gateway Not Found`. 
+an instance of `--port` and/or execute the script target specified by `--script`. If all configured checks - all TCP
+connections and zero exit status for the script - succeed, it will return `HTTP 200 OK`. If any of the checks fail,
+it will return `HTTP 504 Gateway Not Found`.
 
 Configure your AWS Health Check to only pass the Health Check on `HTTP 200 OK`. Now when an HTTP Health Check request
 comes in, all desired TCP ports will be checked and the script target executed.
@@ -49,15 +49,16 @@ health-checker [options]
 
 #### Options
 
-| Option | Description | Default 
+| Option | Description | Default
 | ------ | ----------- | -------
-| `--port` | The port number on which a TCP connection will be attempted. Specify one or more times. | | 
+| `--port` | The port number on which a TCP connection will be attempted. Specify one or more times. | |
 | `--listener` |  The IP address and port on which inbound HTTP connections will be accepted. | `0.0.0.0:5000`
-| `--log-level` | Set the log level to LEVEL. Must be one of: `panic`, `fatal`, `error,` `warning`, `info`, or `debug` | `info` 
-| `--help` | Show the help screen | | 
-| `--script` | Path to script to run - will pass if it completes within configured timeout with a zero exit status. Specify one or more times. | | 
-| `--script-timeout` | Timeout, in seconds, to wait for the scripts to exit. Applies to all configured script targets. | `5` |  
-| `--version` | Show the program's version | | 
+| `--log-level` | Set the log level to LEVEL. Must be one of: `panic`, `fatal`, `error,` `warning`, `info`, or `debug` | `info`
+| `--help` | Show the help screen | |
+| `--script` | Path to script to run - will pass if it completes within configured timeout with a zero exit status. Specify one or more times. | |
+| `--script-timeout` | Timeout, in seconds, to wait for the scripts to exit. Applies to all configured script targets. | `5` |
+| `--singleflight` | Enables single flight mode, which allows concurrent health check requests to share the results of a single check.  | |
+| `--version` | Show the program's version | |
 
 If you execute a shell script, ensure you have a `shebang` line in your script, otherwise the script will fail with an `exec format error`.
 
@@ -90,4 +91,3 @@ attempt to run the configured scripts. If both return exit code zero, return `HT
 ```
 health-checker --listener "0.0.0.0:6000" --script "/usr/local/bin/exhibitor-health-check.sh --exhibitor-port 8080" --script "/usr/local/bin/zk-health-check.sh --zk-port 2191"
 ```
-

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -2,12 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/gruntwork-io/gruntwork-cli/logging"
 	"github.com/gruntwork-io/health-checker/options"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"os"
-	"strings"
 )
 
 const DEFAULT_LISTENER_IP_ADDRESS = "0.0.0.0"
@@ -31,6 +32,11 @@ var scriptTimeoutFlag = cli.IntFlag{
 	Value: DEFAULT_SCRIPT_TIMEOUT_SEC,
 }
 
+var singleflightFlag = cli.BoolFlag{
+	Name:  "singleflight",
+	Usage: fmt.Sprintf("[Optional] Enable singleflight mode, which makes concurrent requests share the same check."),
+}
+
 var listenerFlag = cli.StringFlag{
 	Name:  "listener",
 	Usage: fmt.Sprintf("[Optional] The IP address and port on which inbound HTTP connections will be accepted."),
@@ -47,6 +53,7 @@ var defaultFlags = []cli.Flag{
 	portFlag,
 	scriptFlag,
 	scriptTimeoutFlag,
+	singleflightFlag,
 	listenerFlag,
 	logLevelFlag,
 }
@@ -80,6 +87,8 @@ func parseOptions(cliContext *cli.Context) (*options.Options, error) {
 		return nil, OneOfParamsRequired{portFlag.Name, scriptFlag.Name}
 	}
 
+	singleflight := cliContext.Bool("singleflight")
+
 	scriptTimeout := cliContext.Int("script-timeout")
 
 	listener := cliContext.String("listener")
@@ -91,6 +100,7 @@ func parseOptions(cliContext *cli.Context) (*options.Options, error) {
 		Ports:         ports,
 		Scripts:       scripts,
 		ScriptTimeout: scriptTimeout,
+		Singleflight:  singleflight,
 		Listener:      listener,
 		Logger:        logger,
 	}, nil

--- a/options/options.go
+++ b/options/options.go
@@ -1,8 +1,9 @@
 package options
 
 import (
-	"github.com/sirupsen/logrus"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // The options accepted by this CLI tool
@@ -10,6 +11,7 @@ type Options struct {
 	Ports         []int
 	Scripts       []Script
 	ScriptTimeout int
+	Singleflight  bool
 	Listener      string
 	Logger        *logrus.Logger
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,13 +3,15 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/gruntwork-cli/errors"
-	"github.com/gruntwork-io/health-checker/options"
 	"net"
 	"net/http"
 	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/gruntwork-io/health-checker/options"
+	"golang.org/x/sync/singleflight"
 )
 
 type httpResponse struct {
@@ -18,20 +20,41 @@ type httpResponse struct {
 }
 
 func StartHttpServer(opts *options.Options) error {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		resp := runChecks(opts)
-		err := writeHttpResponse(w, resp)
-		if err != nil {
-			opts.Logger.Error("Failed to send HTTP response. Exiting.")
-			panic(err)
-		}
-	})
+	http.HandleFunc("/", httpHandler(opts))
+
 	err := http.ListenAndServe(opts.Listener, nil)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func httpHandler(opts *options.Options) http.HandlerFunc {
+	var group singleflight.Group
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var resp *httpResponse
+
+		// In Singleflight mode only one runChecks pass will be performed
+		// at any given time, with the result being shared across concurrent
+		// inbound requests
+		if opts.Singleflight {
+			result, _, _ := group.Do("check", func() (interface{}, error) {
+				return runChecks(opts), nil
+			})
+
+			resp = result.(*httpResponse)
+		} else {
+			resp = runChecks(opts)
+		}
+
+		err := writeHttpResponse(w, resp)
+		if err != nil {
+			opts.Logger.Error("Failed to send HTTP response. Exiting.")
+			panic(err)
+		}
+	}
 }
 
 // Check that we can open a TPC connection to all the ports in opts.Ports


### PR DESCRIPTION
Hello there!

This is a quick little addition I whipped up to solve an issue we were having. Our health check script can take a few seconds complete, so this change prevents concurrent incoming status checks from spawning multiple instances of the health check script.